### PR TITLE
KinFit strategy updates

### DIFF
--- a/processing/interface/kinfitter.hh
+++ b/processing/interface/kinfitter.hh
@@ -43,7 +43,6 @@ public:
     KinFitter(std::vector<float> kinINinfo);
     ~KinFitter();
     std::pair<float,float> fit(std::string sgnHp);
-
 };
 
 #endif /* KINFITTER_H_ */

--- a/processing/src/kinfitter.cc
+++ b/processing/src/kinfitter.cc
@@ -159,6 +159,7 @@ std::pair<float,float> KinFitter::fit(std::string sgnHp) {
         }
         else {
             std::cout << "Neither the  mh1_hp,mh2_hp=" << mh1_hp << "," << mh2_hp << " fit nor the mh1_hp,mh2_hp=" << mh2_hp << "," << mh1_hp << " fit converged!!" << std::endl;
+            result = std::pair(-333,-333);
         }
     }
 

--- a/processing/src/kinfitter.cc
+++ b/processing/src/kinfitter.cc
@@ -118,8 +118,8 @@ std::pair<float,float> KinFitter::_fit(int mh1_hp, int mh2_hp) {
       HHKChi2 = KinFit.getChi2(mh1_hp, mh2_hp);
     }
     else {
-      HHKmass = -333;
-      HHKChi2 = -333;
+      HHKmass = std::nanf("1");
+      HHKChi2 = std::nanf("1");
     }
     std::pair<float,float> local_result = std::pair(HHKmass, HHKChi2);
 
@@ -149,17 +149,17 @@ std::pair<float,float> KinFitter::fit(std::string sgnHp) {
         std::pair<float,float> right_fit = _fit(mh1_hp, mh2_hp);
         std::pair<float,float> left_fit  = _fit(mh2_hp, mh1_hp);
 
-        if (right_fit.second != -333 && left_fit.second != -333) {
+        if (right_fit.second != std::nanf("1") && left_fit.second != std::nanf("1")) {
             if (right_fit.second < left_fit.second) { result = right_fit; }
             else { result = left_fit; }
         }
-        else if (right_fit.second != -333 || left_fit.second != -333) {
-            if (right_fit.second != -333) { result = right_fit; }
+        else if (right_fit.second != std::nanf("1") || left_fit.second != std::nanf("1")) {
+            if (right_fit.second != std::nanf("1")) { result = right_fit; }
             else { result = left_fit; }
         }
         else {
             std::cout << "Neither the  mh1_hp,mh2_hp=" << mh1_hp << "," << mh2_hp << " fit nor the mh1_hp,mh2_hp=" << mh2_hp << "," << mh1_hp << " fit converged!!" << std::endl;
-            result = std::pair(-333,-333);
+            result = std::pair(std::nanf("1"),std::nanf("1"));
         }
     }
 

--- a/processing/src/kinfitter.cc
+++ b/processing/src/kinfitter.cc
@@ -1,6 +1,9 @@
 #include "../../../HHKinFit2/HHKinFit2/interface/HHKinFitMasterHeavyHiggs.h"
+#include "../../../HHKinFit2/HHKinFit2/interface/exceptions/HHInvMConstraintException.h"
+#include "../../../HHKinFit2/HHKinFit2/interface/exceptions/HHEnergyRangeException.h"
+#include "../../../HHKinFit2/HHKinFit2/interface/exceptions/HHEnergyConstraintException.h"
+#include "../../../HHKinFit2/HHKinFit2/interface/exceptions/HHLimitSettingException.h"
 #include "cms_runII_data_proc/processing/interface/kinfitter.hh"
-#include <typeinfo>
 
 KinFitter::KinFitter(std::vector<float> kinINinfo) {
     tlv_l1.SetPtEtaPhiM(kinINinfo[0], kinINinfo[1], kinINinfo[2],kinINinfo[3]);
@@ -20,104 +23,107 @@ std::pair<float,float> KinFitter::_fit(int mh1_hp, int mh2_hp) {
     HHKinFit2::HHKinFitMasterHeavyHiggs KinFit = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_b1, tlv_b2, tlv_l1, tlv_l2, ptmiss, metcov);
     KinFit.addHypo(mh1_hp, mh2_hp);
 
-    /* FIXME IF WANTED BUT NOT NECESSARY
+    float HHKmass = -999;
+    float HHKChi2 = -999;
+    bool DEBUG = false;
+
     bool wrongHHK=false;
-    try { KinFit.fit() ; }
-    catch (HHKinFit2::HHInvMConstraintException &e) {
-        cout<<"INVME THIS EVENT WAS WRONG, INV MASS CONSTRAIN EXCEPTION"<<endl;
-        cout<<"INVME masshypo1 = %i,    masshypo2 = %i" % mh1_hp % mh2_hp<<endl;
-        cout<<"INVME Tau1"<<endl;
-        cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_l1.E() <<","<< tlv_l1.Px() <<","<< tlv_l1.Py() <<","<< tlv_l1.Pz() <<","<< tlv_l1.M() << endl;
-        cout<<"INVME Tau2"<<endl;
-        cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_l2.E() <<","<< tlv_l2.Px() <<","<< tlv_l2.Py() <<","<< tlv_l2.Pz() <<","<< tlv_l2.M() << endl;
-        cout<<"INVME B1"<<endl;
-        cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_b1.E() <<","<< tlv_b1.Px() <<","<< tlv_b1.Py() <<","<< tlv_b1.Pz() <<","<< tlv_b1.M() << endl;
-        cout<<"INVME B2"<<endl;
-        cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_b2.E() <<","<< tlv_b2.Px() <<","<< tlv_b2.Py() <<","<< tlv_b2.Pz() <<","<< tlv_b2.M() << endl;
-        cout<<"INVME MET"<<endl;
-        cout<<"INVME (E,Px,Py,Pz,M) "<<","<< ptmiss.Px() <<","<< ptmiss.Py() <<endl;
-        cout<<"INVME METCOV "<<endl;
-        cout<<"INVME "<< metcov (0,0) <<"  "<< metcov (0,1) << endl;
-        cout<<"INVME "<< metcov (1,0) <<"  "<< metcov (1,1) << endl;
-        cout<<"INVME tau1, tau2, b1, b2"<<endl;
-        cout<<"INVME ";
-        tlv_l1.Print();
-        cout<<"INVME ";
-        tlv_l2.Print();
-        cout<<"INVME ";
-        tlv_b1.Print();
-        cout<<"INVME ";
-        tlv_b2.Print();
+    try { KinFit.fit(); }
+    catch (HHKinFit2::HHInvMConstraintException const& e) {
+        std::cout<<"THIS FIT DID NOT CONVERGE: INV MASS CONSTRAIN EXCEPTION (mh1_hp = " << mh1_hp << " , mh2_hp = " << mh2_hp << ")" << std::endl;
+        if (DEBUG) {            
+            std::cout<<"INVME Tau1"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_l1.E() <<","<< tlv_l1.Px() <<","<< tlv_l1.Py() <<","<< tlv_l1.Pz() <<","<< tlv_l1.M() << std::endl;
+            std::cout<<"INVME Tau2"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_l2.E() <<","<< tlv_l2.Px() <<","<< tlv_l2.Py() <<","<< tlv_l2.Pz() <<","<< tlv_l2.M() << std::endl;
+            std::cout<<"INVME B1"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_b1.E() <<","<< tlv_b1.Px() <<","<< tlv_b1.Py() <<","<< tlv_b1.Pz() <<","<< tlv_b1.M() << std::endl;
+            std::cout<<"INVME B2"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<< tlv_b2.E() <<","<< tlv_b2.Px() <<","<< tlv_b2.Py() <<","<< tlv_b2.Pz() <<","<< tlv_b2.M() << std::endl;
+            std::cout<<"INVME MET"<<std::endl;
+            std::cout<<"INVME (E,Px,Py,Pz,M) "<<","<< ptmiss.Px() <<","<< ptmiss.Py() << std::endl;
+            std::cout<<"INVME METCOV "<<std::endl;
+            std::cout<<"INVME "<< metcov (0,0) <<"  "<< metcov (0,1) << std::endl;
+            std::cout<<"INVME "<< metcov (1,0) <<"  "<< metcov (1,1) << std::endl;
+            std::cout<<"INVME tau1, tau2, b1, b2"<<std::endl;
+            std::cout<<"INVME ";
+            tlv_l1.Print();
+            std::cout<<"INVME ";
+            tlv_l2.Print();
+            std::cout<<"INVME ";
+            tlv_b1.Print();
+            std::cout<<"INVME ";
+            tlv_b2.Print();
+        }
         wrongHHK=true;
     }
-    catch (HHKinFit2::HHEnergyRangeException &e) {
-        cout<<"ERANGE THIS EVENT WAS WRONG, INV MASS CONSTRAIN EXCEPTION"<<endl;
-        cout<<"ERANGE masshypo1 = %i,    masshypo2 = %i" % mh1_hp % mh2_hp<<endl;
-        cout<<"ERANGE Tau1"<<endl;
-        cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_l1.E() <<","<< tlv_l1.Px() <<","<< tlv_l1.Py() <<","<< tlv_l1.Pz() <<","<< tlv_l1.M() << endl;
-        cout<<"ERANGE Tau2"<<endl;
-        cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_l2.E() <<","<< tlv_l2.Px() <<","<< tlv_l2.Py() <<","<< tlv_l2.Pz() <<","<< tlv_l2.M() << endl;
-        cout<<"ERANGE B1"<<endl;
-        cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_b1.E() <<","<< tlv_b1.Px() <<","<< tlv_b1.Py() <<","<< tlv_b1.Pz() <<","<< tlv_b1.M() << endl;
-        cout<<"ERANGE B2"<<endl;
-        cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_b2.E() <<","<< tlv_b2.Px() <<","<< tlv_b2.Py() <<","<< tlv_b2.Pz() <<","<< tlv_b2.M() << endl;
-        cout<<"ERANGE MET"<<endl;
-        cout<<"ERANGE (E,Px,Py,Pz,M) "<<","<< ptmiss.Px() <<","<< ptmiss.Py() <<endl;
-        cout<<"ERANGE METCOV "<<endl;
-        cout<<"ERANGE "<< metcov (0,0) <<"  "<< metcov (0,1) << endl;
-        cout<<"ERANGE "<< metcov (1,0) <<"  "<< metcov (1,1) << endl;
-        cout<<"ERANGE tau1, tau2, b1, b2"<<endl;
-        cout<<"ERANGE ";
-        tlv_l1.Print();
-        cout<<"ERANGE ";
-        tlv_l2.Print();
-        cout<<"ERANGE ";
-        tlv_b1.Print();
-        cout<<"ERANGE ";
-        tlv_b2.Print();
+    catch (HHKinFit2::HHEnergyRangeException const& e) {
+        std::cout<<"THIS FIT DID NOT CONVERGE: INV MASS CONSTRAIN EXCEPTION (mh1_hp = " << mh1_hp << " , mh2_hp = " << mh2_hp << ")" << std::endl;
+        if (DEBUG) {
+            std::cout<<"ERANGE Tau1"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_l1.E() <<","<< tlv_l1.Px() <<","<< tlv_l1.Py() <<","<< tlv_l1.Pz() <<","<< tlv_l1.M() << std::endl;
+            std::cout<<"ERANGE Tau2"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_l2.E() <<","<< tlv_l2.Px() <<","<< tlv_l2.Py() <<","<< tlv_l2.Pz() <<","<< tlv_l2.M() << std::endl;
+            std::cout<<"ERANGE B1"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_b1.E() <<","<< tlv_b1.Px() <<","<< tlv_b1.Py() <<","<< tlv_b1.Pz() <<","<< tlv_b1.M() << std::endl;
+            std::cout<<"ERANGE B2"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<< tlv_b2.E() <<","<< tlv_b2.Px() <<","<< tlv_b2.Py() <<","<< tlv_b2.Pz() <<","<< tlv_b2.M() << std::endl;
+            std::cout<<"ERANGE MET"<<std::endl;
+            std::cout<<"ERANGE (E,Px,Py,Pz,M) "<<","<< ptmiss.Px() <<","<< ptmiss.Py() <<std::endl;
+            std::cout<<"ERANGE METCOV "<<std::endl;
+            std::cout<<"ERANGE "<< metcov (0,0) <<"  "<< metcov (0,1) << std::endl;
+            std::cout<<"ERANGE "<< metcov (1,0) <<"  "<< metcov (1,1) << std::endl;
+            std::cout<<"ERANGE tau1, tau2, b1, b2"<<std::endl;
+            std::cout<<"ERANGE ";
+            tlv_l1.Print();
+            std::cout<<"ERANGE ";
+            tlv_l2.Print();
+            std::cout<<"ERANGE ";
+            tlv_b1.Print();
+            std::cout<<"ERANGE ";
+            tlv_b2.Print();
+        }
         wrongHHK=true;
     }
-    catch (HHKinFit2::HHEnergyConstraintException &e) {
-        cout<<"ECON THIS EVENT WAS WRONG, ENERGY CONSTRAIN EXCEPTION"<<endl;
-        cout<<"ECON masshypo1 = %i,    masshypo2 = %i" % mh1_hp % mh2_hp<<endl;
-        cout<<"ECON Tau1"<<endl;
-        cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_l1.E() <<","<< tlv_l1.Px() <<","<< tlv_l1.Py() <<","<< tlv_l1.Pz() <<","<< tlv_l1.M() << endl;
-        cout<<"ECON Tau2"<<endl;
-        cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_l2.E() <<","<< tlv_l2.Px() <<","<< tlv_l2.Py() <<","<< tlv_l2.Pz() <<","<< tlv_l2.M() << endl;
-        cout<<"ECON B1"<<endl;
-        cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_b1.E() <<","<< tlv_b1.Px() <<","<< tlv_b1.Py() <<","<< tlv_b1.Pz() <<","<< tlv_b1.M() << endl;
-        cout<<"ECON B2"<<endl;
-        cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_b2.E() <<","<< tlv_b2.Px() <<","<< tlv_b2.Py() <<","<< tlv_b2.Pz() <<","<< tlv_b2.M() << endl;
-        cout<<"ECON MET"<<endl;
-        cout<<"ECON (E,Px,Py,Pz,M) "<<","<< ptmiss.Px() <<","<< ptmiss.Py() <<endl;
-        cout<<"ECON METCOV "<<endl;
-        cout<<"ECON "<< metcov (0,0) <<"  "<< metcov (0,1) << endl;
-        cout<<"ECON "<< metcov (1,0) <<"  "<< metcov (1,1) << endl;
-        cout<<"ECON tau1, tau2, b1, b2"<<endl;
-        cout<<"ECON ";
-        tlv_l1.Print();
-        cout<<"ECON ";
-        tlv_l2.Print();
-        cout<<"ECON ";
-        tlv_b1.Print();
-        cout<<"ECON ";
-        tlv_b2.Print();
+    catch (HHKinFit2::HHEnergyConstraintException const& e) {
+        std::cout<<"THIS FIT DID NOT CONVERGE: ENERGY CONSTRAIN EXCEPTION (mh1_hp = " << mh1_hp << " , mh2_hp = " << mh2_hp << ")" << std::endl;
+        if (DEBUG) {
+            std::cout<<"ECON Tau1"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_l1.E() <<","<< tlv_l1.Px() <<","<< tlv_l1.Py() <<","<< tlv_l1.Pz() <<","<< tlv_l1.M() << std::endl;
+            std::cout<<"ECON Tau2"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_l2.E() <<","<< tlv_l2.Px() <<","<< tlv_l2.Py() <<","<< tlv_l2.Pz() <<","<< tlv_l2.M() << std::endl;
+            std::cout<<"ECON B1"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_b1.E() <<","<< tlv_b1.Px() <<","<< tlv_b1.Py() <<","<< tlv_b1.Pz() <<","<< tlv_b1.M() << std::endl;
+            std::cout<<"ECON B2"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<< tlv_b2.E() <<","<< tlv_b2.Px() <<","<< tlv_b2.Py() <<","<< tlv_b2.Pz() <<","<< tlv_b2.M() << std::endl;
+            std::cout<<"ECON MET"<<std::endl;
+            std::cout<<"ECON (E,Px,Py,Pz,M) "<<","<< ptmiss.Px() <<","<< ptmiss.Py() <<std::endl;
+            std::cout<<"ECON METCOV "<<std::endl;
+            std::cout<<"ECON "<< metcov (0,0) <<"  "<< metcov (0,1) << std::endl;
+            std::cout<<"ECON "<< metcov (1,0) <<"  "<< metcov (1,1) << std::endl;
+            std::cout<<"ECON tau1, tau2, b1, b2"<<std::endl;
+            std::cout<<"ECON ";
+            tlv_l1.Print();
+            std::cout<<"ECON ";
+            tlv_l2.Print();
+            std::cout<<"ECON ";
+            tlv_b1.Print();
+            std::cout<<"ECON ";
+            tlv_b2.Print();
+        }
         wrongHHK=true;
     }
     if(!wrongHHK) {
-      HHKmass = kinFits.getMH();
-      HHKChi2 = kinFits.getChi2();
+      HHKmass = KinFit.getMH(mh1_hp, mh2_hp);
+      HHKChi2 = KinFit.getChi2(mh1_hp, mh2_hp);
     }
     else {
       HHKmass = -333;
+      HHKChi2 = -333;
     }
-    std::pair<float,float> result = std::pair(HHKmass, HHKChi2);
-    */
+    std::pair<float,float> local_result = std::pair(HHKmass, HHKChi2);
 
-    KinFit.fit();
-    std::pair<float,float> result = std::pair(KinFit.getMH(), KinFit.getChi2());
-
-    return result;
+    return local_result;
 }
 
 std::pair<float,float> KinFitter::fit(std::string sgnHp) {
@@ -134,5 +140,27 @@ std::pair<float,float> KinFitter::fit(std::string sgnHp) {
         mh2_hp = H_MASS;
     }
 
-    return _fit(mh1_hp, mh2_hp);
+    std::pair<float,float> result = std::pair(-999,-999);
+
+    if (mh1_hp == mh2_hp) {
+        result = _fit(mh1_hp, mh2_hp);
+    }
+    else {
+        std::pair<float,float> right_fit = _fit(mh1_hp, mh2_hp);
+        std::pair<float,float> left_fit  = _fit(mh2_hp, mh1_hp);
+
+        if (right_fit.second != -333 && left_fit.second != -333) {
+            if (right_fit.second < left_fit.second) { result = right_fit; }
+            else { result = left_fit; }
+        }
+        else if (right_fit.second != -333 || left_fit.second != -333) {
+            if (right_fit.second != -333) { result = right_fit; }
+            else { result = left_fit; }
+        }
+        else {
+            std::cout << "Neither the  mh1_hp,mh2_hp=" << mh1_hp << "," << mh2_hp << " fit nor the mh1_hp,mh2_hp=" << mh2_hp << "," << mh1_hp << " fit converged!!" << std::endl;
+        }
+    }
+
+    return result;
 }


### PR DESCRIPTION
In this new version two things are implemented:
1. in the case in which mhp1!=mhp2, two fits are run swapping the two hypotheses and retaining the one with the lowest Chi2
2. full catching of the errors is now available, together with a DEBUG output. In case the fit does not converge the fitted Mass and Chi2 are set by default to `-333`

To make these new features work it is necessary to pull HHKinFit2 from `git@github.com:jonamotta/HHKinFit2.git` in the branch `bbtautau_Run2DNNtraining`